### PR TITLE
Add MCP Apple automation server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# mcp-chatgpt-apple
+# MCP Apple Automation Server
+
+This project provides a lightweight MCP (Message Control Protocol) server to automate native macOS applications. Each application is implemented as a separate module using AppleScript executed via `osascript`.
+
+## Features
+
+- **Messages** – send SMS/iMessage
+- **Mail** – send email through Mail.app
+- **Calendar** – create calendar events
+- **Reminders** – create reminders
+- **Notes** – create notes
+
+The implementation avoids external Node packages and relies only on built‑in `http` and `child_process` modules so it can run in restricted environments.
+
+## Usage
+
+1. Start the server:
+   ```bash
+   node server/index.js
+   ```
+2. Send HTTP POST requests to control each app:
+   - `POST /messages` with `{ "recipient": "+15551234567", "text": "Hello" }`
+   - `POST /mail` with `{ "to": "name@example.com", "subject": "Hi", "content": "Body" }`
+   - `POST /calendar` with `{ "title": "Meeting", "date": "2024-07-01T10:00:00" }`
+   - `POST /reminders` with `{ "name": "Task", "dueDate": "2024-07-01T12:00:00" }`
+   - `POST /notes` with `{ "title": "Note", "content": "My note" }`
+
+## macOS Permissions
+
+Running AppleScript requires that the Node.js executable be granted automation permissions. On first use macOS will prompt for permissions for Messages, Mail, Calendar, Reminders and Notes.
+
+## Limitations
+
+- The server must run on macOS to access AppleScript APIs.
+- Error handling and authentication are minimal.
+
+## Development
+
+All source files are under the `server` directory.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mcp-chatgpt-apple",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server/apps/calendar.js
+++ b/server/apps/calendar.js
@@ -1,0 +1,22 @@
+const { exec } = require('child_process');
+exports.handle = function(body, res) {
+  const { title, date } = body || {};
+  if (!title || !date) {
+    res.statusCode = 400;
+    return res.end('Missing fields');
+  }
+  const script = `tell application "Calendar"
+    tell calendar "Home"
+      make new event with properties {summary:"${title.replace(/"/g,'\\"')}", start date:date "${date}", end date:date "${date}" + (1 * hours)}
+    end tell
+end tell`;
+  exec(`osascript -e '${script}'`, err => {
+    if (err) {
+      console.error('Calendar error:', err);
+      res.statusCode = 500;
+      res.end('Failed to create event');
+    } else {
+      res.end('Event created');
+    }
+  });
+};

--- a/server/apps/mail.js
+++ b/server/apps/mail.js
@@ -1,0 +1,24 @@
+const { exec } = require('child_process');
+exports.handle = function(body, res) {
+  const { to, subject, content } = body || {};
+  if (!to || !subject || !content) {
+    res.statusCode = 400;
+    return res.end('Missing fields');
+  }
+  const script = `tell application "Mail"
+    set newMessage to make new outgoing message with properties {subject:"${subject.replace(/"/g,'\\"')}", content:"${content.replace(/"/g,'\\"')}", visible:false}
+    tell newMessage
+        make new to recipient at end of to recipients with properties {address:"${to}"}
+        send
+    end tell
+end tell`;
+  exec(`osascript -e '${script}'`, err => {
+    if (err) {
+      console.error('Mail error:', err);
+      res.statusCode = 500;
+      res.end('Failed to send mail');
+    } else {
+      res.end('Mail sent');
+    }
+  });
+};

--- a/server/apps/messages.js
+++ b/server/apps/messages.js
@@ -1,0 +1,18 @@
+const { exec } = require('child_process');
+exports.handle = function(body, res) {
+  const { recipient, text } = body || {};
+  if (!recipient || !text) {
+    res.statusCode = 400;
+    return res.end('Missing recipient or text');
+  }
+  const script = `tell application "Messages" to send "${text.replace(/"/g,'\\"')}" to buddy "${recipient}" of service "SMS"`;
+  exec(`osascript -e '${script}'`, err => {
+    if (err) {
+      console.error('Messages error:', err);
+      res.statusCode = 500;
+      res.end('Failed to send message');
+    } else {
+      res.end('Message sent');
+    }
+  });
+};

--- a/server/apps/notes.js
+++ b/server/apps/notes.js
@@ -1,0 +1,22 @@
+const { exec } = require('child_process');
+exports.handle = function(body, res) {
+  const { title, content } = body || {};
+  if (!title || !content) {
+    res.statusCode = 400;
+    return res.end('Missing fields');
+  }
+  const script = `tell application "Notes"
+    tell account 1
+      make new note at folder "Notes" with properties {name:"${title.replace(/"/g,'\\"')}", body:"${content.replace(/"/g,'\\"')}"}
+    end tell
+end tell`;
+  exec(`osascript -e '${script}'`, err => {
+    if (err) {
+      console.error('Notes error:', err);
+      res.statusCode = 500;
+      res.end('Failed to create note');
+    } else {
+      res.end('Note created');
+    }
+  });
+};

--- a/server/apps/reminders.js
+++ b/server/apps/reminders.js
@@ -1,0 +1,19 @@
+const { exec } = require('child_process');
+exports.handle = function(body, res) {
+  const { name, dueDate } = body || {};
+  if (!name) {
+    res.statusCode = 400;
+    return res.end('Missing name');
+  }
+  const duePart = dueDate ? `, due date:date "${dueDate}"` : '';
+  const script = `tell application "Reminders" to make new reminder with properties {name:"${name.replace(/"/g,'\\"')}"${duePart}}`;
+  exec(`osascript -e '${script}'`, err => {
+    if (err) {
+      console.error('Reminders error:', err);
+      res.statusCode = 500;
+      res.end('Failed to create reminder');
+    } else {
+      res.end('Reminder created');
+    }
+  });
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,53 @@
+const http = require('http');
+const { URL } = require('url');
+const messages = require('./apps/messages');
+const mail = require('./apps/mail');
+const calendar = require('./apps/calendar');
+const reminders = require('./apps/reminders');
+const notes = require('./apps/notes');
+
+const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+
+function parseBody(req, cb) {
+  let data = '';
+  req.on('data', chunk => { data += chunk; });
+  req.on('end', () => {
+    try {
+      cb(null, data ? JSON.parse(data) : {});
+    } catch (err) {
+      cb(err);
+    }
+  });
+  req.on('error', err => cb(err));
+}
+
+http.createServer((req, res) => {
+  if (!req.url || req.method !== 'POST') {
+    res.statusCode = 404;
+    return res.end('Not Found');
+  }
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  parseBody(req, (err, body) => {
+    if (err) {
+      res.statusCode = 400;
+      return res.end('Bad Request');
+    }
+    switch (url.pathname) {
+      case '/messages':
+        messages.handle(body, res); break;
+      case '/mail':
+        mail.handle(body, res); break;
+      case '/calendar':
+        calendar.handle(body, res); break;
+      case '/reminders':
+        reminders.handle(body, res); break;
+      case '/notes':
+        notes.handle(body, res); break;
+      default:
+        res.statusCode = 404;
+        res.end('Not Found');
+    }
+  });
+}).listen(PORT, () => {
+  console.log(`MCP Apple server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node-based MCP server to automate macOS apps via AppleScript
- document features and usage in README
- provide package.json with start script

## Testing
- `node server/index.js & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_b_685078e4a29083279693a90ce17bf95f