### PR TITLE
Implement basic MCP server for macOS apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
-# mcp-chatgpt-apple
+# MCP ChatGPT Apple Server
+
+This project provides a minimal MCP server that allows AnythingLLM to control
+native macOS applications such as Messages, Mail, Calendar, Reminders and Notes.
+The server is written in TypeScript and communicates with macOS applications via
+AppleScript.
+
+## Requirements
+
+- macOS with AppleScript support
+- Node.js 18+
+- TypeScript (`tsc` command)
+
+## Installation
+
+```bash
+npm run build
+```
+
+## Running the server
+
+```bash
+npm start
+```
+
+The server listens on port `3000` by default. Send `POST` requests with a JSON
+body containing an `action` field and associated `data`.
+
+Example:
+
+```bash
+curl -X POST http://localhost:3000 -d '{"action":"sendMessage","data":{"recipient":"John","message":"Hi"}}'
+```
+
+Another example to create a note:
+
+```bash
+curl -X POST http://localhost:3000 -d '{"action":"createNote","data":{"title":"Shopping","body":"Eggs, Milk"}}'
+```
+
+## Tests
+
+Run the test suite with:
+
+```bash
+npm test
+```
+
+This compiles the TypeScript sources and executes a small set of unit tests for
+the AppleScript builders.
+
+## Connecting AnythingLLM
+
+Create an `anythingllm_mcp_servers.json` file alongside your AnythingLLM
+configuration with the following contents:
+
+```json
+[
+  {
+    "name": "macOS MCP",
+    "url": "http://localhost:3000"
+  }
+]
+```
+
+Restart AnythingLLM and it will be able to send actions to this server.

--- a/anythingllm_mcp_servers.json
+++ b/anythingllm_mcp_servers.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "macOS MCP",
+    "url": "http://localhost:3000"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mcp-chatgpt-apple",
+  "version": "0.1.0",
+  "description": "MCP server for controlling Apple applications via AnythingLLM",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "node tests/run-tests.js"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Placeholder setup script
+npm run build

--- a/src/apps/calendar.ts
+++ b/src/apps/calendar.ts
@@ -1,0 +1,33 @@
+import { exec } from 'child_process';
+import { log, error } from '../utils/logger';
+
+export interface EventOptions {
+  title: string;
+  startDate: string; // ISO format
+  endDate: string;   // ISO format
+}
+
+export function buildCreateEventScript(opts: EventOptions): string {
+  return `
+  tell application "Calendar"
+    tell calendar "Home"
+      make new event with properties {summary:"${opts.title}", start date:date "${opts.startDate}", end date:date "${opts.endDate}"}
+    end tell
+  end tell`;
+}
+
+export function createEvent(opts: EventOptions): Promise<void> {
+  const script = buildCreateEventScript(opts);
+
+  return new Promise((resolve, reject) => {
+    exec(`osascript -e ${JSON.stringify(script)}`, (err) => {
+      if (err) {
+        error(`Failed to create event: ${err}`);
+        reject(err);
+        return;
+      }
+      log(`Created calendar event '${opts.title}'`);
+      resolve();
+    });
+  });
+}

--- a/src/apps/mail.ts
+++ b/src/apps/mail.ts
@@ -1,0 +1,35 @@
+import { exec } from 'child_process';
+import { log, error } from '../utils/logger';
+
+export interface MailOptions {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+export function buildSendMailScript(opts: MailOptions): string {
+  return `
+  tell application "Mail"
+    set newMessage to make new outgoing message with properties {subject:"${opts.subject}", content:"${opts.body}\n" & signature name}
+    tell newMessage
+      make new to recipient at end of to recipients with properties {address:"${opts.to}"}
+      send
+    end tell
+  end tell`;
+}
+
+export function sendMail(opts: MailOptions): Promise<void> {
+  const script = buildSendMailScript(opts);
+
+  return new Promise((resolve, reject) => {
+    exec(`osascript -e ${JSON.stringify(script)}`, (err) => {
+      if (err) {
+        error(`Failed to send mail: ${err}`);
+        reject(err);
+        return;
+      }
+      log(`Sent mail to ${opts.to}`);
+      resolve();
+    });
+  });
+}

--- a/src/apps/messages.ts
+++ b/src/apps/messages.ts
@@ -1,0 +1,25 @@
+import { exec } from 'child_process';
+import { log, error } from '../utils/logger';
+
+export function buildSendMessageScript(recipient: string, message: string): string {
+  return `
+  tell application "Messages"
+    send "${message}" to buddy "${recipient}" of service "SMS"
+  end tell`;
+}
+
+export function sendMessage(recipient: string, message: string): Promise<void> {
+  const script = buildSendMessageScript(recipient, message);
+
+  return new Promise((resolve, reject) => {
+    exec(`osascript -e ${JSON.stringify(script)}`, (err) => {
+      if (err) {
+        error(`Failed to send message: ${err}`);
+        reject(err);
+        return;
+      }
+      log(`Sent message to ${recipient}`);
+      resolve();
+    });
+  });
+}

--- a/src/apps/notes.ts
+++ b/src/apps/notes.ts
@@ -1,0 +1,27 @@
+import { exec } from 'child_process';
+import { log, error } from '../utils/logger';
+
+export function buildCreateNoteScript(title: string, body: string): string {
+  return `
+  tell application "Notes"
+    tell account "iCloud"
+      make new note at folder "Notes" with properties {name:"${title}", body:"${body}"}
+    end tell
+  end tell`;
+}
+
+export function createNote(title: string, body: string): Promise<void> {
+  const script = buildCreateNoteScript(title, body);
+
+  return new Promise((resolve, reject) => {
+    exec(`osascript -e ${JSON.stringify(script)}`, (err) => {
+      if (err) {
+        error(`Failed to create note: ${err}`);
+        reject(err);
+        return;
+      }
+      log(`Created note '${title}'`);
+      resolve();
+    });
+  });
+}

--- a/src/apps/reminders.ts
+++ b/src/apps/reminders.ts
@@ -1,0 +1,25 @@
+import { exec } from 'child_process';
+import { log, error } from '../utils/logger';
+
+export function buildAddReminderScript(text: string): string {
+  return `
+  tell application "Reminders"
+    make new reminder with properties {name:"${text}"}
+  end tell`;
+}
+
+export function addReminder(text: string): Promise<void> {
+  const script = buildAddReminderScript(text);
+
+  return new Promise((resolve, reject) => {
+    exec(`osascript -e ${JSON.stringify(script)}`, (err) => {
+      if (err) {
+        error(`Failed to add reminder: ${err}`);
+        reject(err);
+        return;
+      }
+      log(`Added reminder '${text}'`);
+      resolve();
+    });
+  });
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,5 @@
+declare module 'child_process';
+declare module 'http';
+declare module 'assert';
+declare var process: any;
+declare var require: any;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,68 @@
+const http = require('http');
+import { log } from './utils/logger';
+import { sendMessage } from './apps/messages';
+import { sendMail } from './apps/mail';
+import { createEvent } from './apps/calendar';
+import { addReminder } from './apps/reminders';
+import { createNote } from './apps/notes';
+
+const PORT = process.env.PORT || 3000;
+
+interface RequestBody {
+  action: string;
+  data: any;
+}
+
+function parseBody(req: any): Promise<RequestBody> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(body));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    return res.end();
+  }
+
+  try {
+    const body = await parseBody(req);
+    switch (body.action) {
+      case 'sendMessage':
+        await sendMessage(body.data.recipient, body.data.message);
+        break;
+      case 'sendMail':
+        await sendMail(body.data);
+        break;
+      case 'createEvent':
+        await createEvent(body.data);
+        break;
+      case 'addReminder':
+        await addReminder(body.data.text);
+        break;
+      case 'createNote':
+        await createNote(body.data.title, body.data.body);
+        break;
+      default:
+        res.statusCode = 400;
+        return res.end('Unknown action');
+    }
+    res.statusCode = 200;
+    res.end('ok');
+  } catch (err) {
+    res.statusCode = 500;
+    res.end('error');
+  }
+});
+
+server.listen(PORT, () => {
+  log(`MCP server listening on port ${PORT}`);
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,9 @@
+export function log(message: string) {
+  const timestamp = new Date().toISOString();
+  console.log(`[${timestamp}] ${message}`);
+}
+
+export function error(message: string) {
+  const timestamp = new Date().toISOString();
+  console.error(`[${timestamp}] ERROR: ${message}`);
+}

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,0 +1,11 @@
+import { execSync } from 'child_process';
+import { log } from './logger';
+
+export function requestPermission(bundleId: string) {
+  try {
+    execSync(`tccutil reset All ${bundleId}`);
+    log(`Requested permissions for ${bundleId}`);
+  } catch (err) {
+    log(`Could not request permissions for ${bundleId}: ${err}`);
+  }
+}

--- a/tests/calendar.test.ts
+++ b/tests/calendar.test.ts
@@ -1,0 +1,8 @@
+import assert from 'assert';
+import { buildCreateEventScript, EventOptions } from '../src/apps/calendar';
+
+const opts: EventOptions = { title: 'Meet', startDate: '2024-01-01T10:00:00Z', endDate: '2024-01-01T11:00:00Z' };
+const script = buildCreateEventScript(opts);
+assert(script.includes('Meet'));
+assert(script.includes('start date:date'));
+console.log('calendar.test passed');

--- a/tests/mail.test.ts
+++ b/tests/mail.test.ts
@@ -1,0 +1,8 @@
+import assert from 'assert';
+import { buildSendMailScript, MailOptions } from '../src/apps/mail';
+
+const opts: MailOptions = { to: 'user@example.com', subject: 'Test', body: 'Hi' };
+const script = buildSendMailScript(opts);
+assert(script.includes('user@example.com'));
+assert(script.includes('subject:"Test"'));
+console.log('mail.test passed');

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -1,0 +1,7 @@
+import assert from 'assert';
+import { buildSendMessageScript } from '../src/apps/messages';
+
+const script = buildSendMessageScript('TestUser', 'Hello');
+assert(script.includes('send "Hello"'));
+assert(script.includes('buddy "TestUser"'));
+console.log('messages.test passed');

--- a/tests/notes.test.ts
+++ b/tests/notes.test.ts
@@ -1,0 +1,7 @@
+import assert from 'assert';
+import { buildCreateNoteScript } from '../src/apps/notes';
+
+const script = buildCreateNoteScript('Title', 'Body');
+assert(script.includes('Title'));
+assert(script.includes('Body'));
+console.log('notes.test passed');

--- a/tests/reminders.test.ts
+++ b/tests/reminders.test.ts
@@ -1,0 +1,6 @@
+import assert from 'assert';
+import { buildAddReminderScript } from '../src/apps/reminders';
+
+const script = buildAddReminderScript('Buy milk');
+assert(script.includes('Buy milk'));
+console.log('reminders.test passed');

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,16 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+// compile TypeScript
+const tsc = spawnSync('tsc', [], { stdio: 'inherit' });
+if (tsc.status !== 0) process.exit(tsc.status);
+
+const testsDir = path.join(__dirname, '../dist/tests');
+const tests = fs.readdirSync(testsDir).filter(f => f.endsWith('.test.js'));
+let failed = false;
+for (const test of tests) {
+  const result = spawnSync('node', [path.join(testsDir, test)], { stdio: 'inherit' });
+  if (result.status !== 0) failed = true;
+}
+process.exitCode = failed ? 1 : 0;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": false,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- set up TypeScript project with build/test scripts
- implement modular MCP server for Messages, Mail, Calendar, Reminders and Notes
- add small unit tests for AppleScript builders
- document usage in README
- provide example AnythingLLM configuration file

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685078e4a29083279693a90ce17bf95f